### PR TITLE
Welcome notice

### DIFF
--- a/class-ti-about-page.php
+++ b/class-ti-about-page.php
@@ -65,7 +65,8 @@ class Ti_About_Page {
 	public function setup_actions() {
 
 		add_action( 'admin_menu', array( $this, 'register' ) );
-		add_action( 'load-themes.php', array( $this, 'admin_notice_activation' ) );
+//		add_action( 'load-themes.php', array( $this, 'admin_notice_activation' ) );
+		add_action( 'admin_notices', array( $this, 'welcome_notice' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
 		add_action(
 			'wp_ajax_update_recommended_plugins_visibility', array(
@@ -131,9 +132,9 @@ class Ti_About_Page {
 
 		wp_register_script(
 			'ti-about-scripts', TI_ABOUT_PAGE_URL . '/js/ti_about_page_scripts.js', array(
-				'jquery',
-				'jquery-ui-tabs',
-			), TI_ABOUT_PAGE_VERSION, true
+			'jquery',
+			'jquery-ui-tabs',
+		), TI_ABOUT_PAGE_VERSION, true
 		);
 
 		wp_localize_script(
@@ -231,21 +232,36 @@ class Ti_About_Page {
 		wp_send_json( $required_actions_left );
 	}
 
-	public function admin_notice_activation() {
-
-		global $pagenow;
-		if ( is_admin() && ( 'themes.php' == $pagenow ) && isset( $_GET['activated'] ) ) {
-			add_action( 'admin_notices', array( $this, 'welcome_notice' ), 99 );
-		}
-	}
+//	public function admin_notice_activation() {
+//
+//		global $pagenow;
+//		if ( is_admin() && ( 'themes.php' == $pagenow ) && isset( $_GET['activated'] ) ) {
+//			add_action( 'admin_notices', array( $this, 'welcome_notice' ), 99 );
+//		}
+//	}
 
 	public function welcome_notice() {
 
+		if ( ! isset( $this->config['welcome_notice'] ) ) {
+			return;
+		}
+
+		$default = array(
+			'type' => 'default',
+			'render_callback' => array( $this, 'render_notice' ),
+		);
+
+		$this->config['welcome_notice'] = wp_parse_args( $this->config['welcome_notice'], $default );
+
+		echo '<div class="updated notice is-dismissible ti-about-notice">';
+		call_user_func( $this->config['welcome_notice']['render_callback'] );
+		echo '</div>';
+	}
+
+	public function render_notice() {
 		$url = admin_url( 'themes.php?page=' . $this->theme_args['slug'] . '-welcome' );
 		$notice = apply_filters( 'ti_about_welcome_notice_filter', ( '<p>' . sprintf( 'Welcome! Thank you for choosing %1$s! To fully take advantage of the best our theme can offer please make sure you visit our %2$swelcome page%3$s.', $this->theme_args['name'], '<a href="' . esc_url( admin_url( 'themes.php?page=' . $this->theme_args['slug'] . '-welcome' ) ) . '">', '</a>' ) . '</p><p><a href="' . esc_url( $url ) . '" class="button" style="text-decoration: none;">' . sprintf( 'Get started with %s', $this->theme_args['name'] ) . '</a></p>' ) );
 
-		echo '<div class="updated notice is-dismissible">';
 		echo wp_kses_post( $notice );
-		echo '</div>';
 	}
 }

--- a/class-ti-about-page.php
+++ b/class-ti-about-page.php
@@ -253,10 +253,12 @@ class Ti_About_Page {
 		$default = array(
 			'type' => 'default',
 			'render_callback' => array( $this, 'render_notice' ),
+			'dismiss_option' => 'ti_about_welcome_notice',
+			'notice_class' => '',
 		);
 
 		$this->config['welcome_notice'] = wp_parse_args( $this->config['welcome_notice'], $default );
-		echo '<div class="updated notice is-dismissible ti-about-notice">';
+		echo '<div class="' . esc_attr( $this->config['welcome_notice']['notice_class'] ) . ' notice is-dismissible ti-about-notice">';
 		call_user_func( $this->config['welcome_notice']['render_callback'] );
 		echo '</div>';
 	}
@@ -289,7 +291,7 @@ class Ti_About_Page {
 		if ( ! isset( $params['nonce'] ) || ! wp_verify_nonce( $params['nonce'], 'dismiss_ti_about_notice' ) ) {
 			wp_send_json_error( 'Wrong nonce' );
 		}
-		add_user_meta( $user_id, 'ti_about_welcome_notice', 'dismissed', true );
+		add_user_meta( $user_id, $this->config['welcome_notice']['dismiss_option'], 'dismissed', true );
 		wp_send_json_success( 'Dismiss import' );
 	}
 

--- a/class-ti-about-page.php
+++ b/class-ti-about-page.php
@@ -238,6 +238,15 @@ class Ti_About_Page {
 	 */
 	public function welcome_notice() {
 
+		/**
+		 * Handle edge case for Zerif
+		 */
+		if ( defined( 'ZERIF_VERSION' ) || defined( 'ZERIF_LITE_VERSION' ) ) {
+			if ( get_option( 'zelle_notice_dismissed' ) === 'yes' ) {
+				return;
+			}
+		}
+
 		if ( ! isset( $this->config['welcome_notice'] ) ) {
 			return;
 		}
@@ -245,6 +254,7 @@ class Ti_About_Page {
 		global $current_user;
 		$user_id = $current_user->ID;
 		$dismissed_notice = get_user_meta( $user_id, $this->config['welcome_notice']['dismiss_option'], true );
+
 
 		if ( $dismissed_notice === 'dismissed' ) {
 			return;

--- a/class-ti-about-page.php
+++ b/class-ti-about-page.php
@@ -244,7 +244,7 @@ class Ti_About_Page {
 
 		global $current_user;
 		$user_id = $current_user->ID;
-		$dismissed_notice = get_user_meta( $user_id, 'ti_about_welcome_notice', true );
+		$dismissed_notice = get_user_meta( $user_id, $this->config['welcome_notice']['dismiss_option'], true );
 
 		if ( $dismissed_notice === 'dismissed' ) {
 			return;

--- a/class-ti-about-page.php
+++ b/class-ti-about-page.php
@@ -57,6 +57,15 @@ class Ti_About_Page {
 		$this->theme_args['version']     = $theme->__get( 'Version' );
 		$this->theme_args['description'] = $theme->__get( 'Description' );
 		$this->theme_args['slug']        = $theme->__get( 'stylesheet' );
+
+		$default = array(
+			'type' => 'default',
+			'render_callback' => array( $this, 'render_notice' ),
+			'dismiss_option' => 'ti_about_welcome_notice',
+			'notice_class' => '',
+		);
+
+		$this->config['welcome_notice'] = wp_parse_args( $this->config['welcome_notice'], $default );
 	}
 
 	/**
@@ -254,20 +263,10 @@ class Ti_About_Page {
 		global $current_user;
 		$user_id = $current_user->ID;
 		$dismissed_notice = get_user_meta( $user_id, $this->config['welcome_notice']['dismiss_option'], true );
-
-
 		if ( $dismissed_notice === 'dismissed' ) {
 			return;
 		}
 
-		$default = array(
-			'type' => 'default',
-			'render_callback' => array( $this, 'render_notice' ),
-			'dismiss_option' => 'ti_about_welcome_notice',
-			'notice_class' => '',
-		);
-
-		$this->config['welcome_notice'] = wp_parse_args( $this->config['welcome_notice'], $default );
 		echo '<div class="' . esc_attr( $this->config['welcome_notice']['notice_class'] ) . ' notice is-dismissible ti-about-notice">';
 		call_user_func( $this->config['welcome_notice']['render_callback'] );
 		echo '</div>';
@@ -292,17 +291,11 @@ class Ti_About_Page {
 		global $current_user;
 		$user_id = $current_user->ID;
 
-		$dismissed_notice = get_user_meta( $user_id, 'ti_about_welcome_notice', true );
-
-		if ( $dismissed_notice === 'dismissed' ) {
-			return;
-		}
-
 		if ( ! isset( $params['nonce'] ) || ! wp_verify_nonce( $params['nonce'], 'dismiss_ti_about_notice' ) ) {
 			wp_send_json_error( 'Wrong nonce' );
 		}
 		add_user_meta( $user_id, $this->config['welcome_notice']['dismiss_option'], 'dismissed', true );
-		wp_send_json_success( 'Dismiss import' );
+		wp_send_json_success( 'Dismiss notice' );
 	}
 
 	/**

--- a/includes/class-ti-about-render.php
+++ b/includes/class-ti-about-render.php
@@ -70,12 +70,12 @@ class TI_About_Render {
 	private function render_header() {
 
 		?>
-		<div class="header">
-			<div class="info"><h1>Welcome to <?php echo esc_html( $this->theme['name'] ); ?>! - Version <span
-							class="version-container"><?php echo esc_html( $this->theme['version'] ); ?></span></h1>
-				<div class="ti-about-header-text about-text"><?php echo esc_html( $this->theme['description'] ); ?></div>
-			</div>
-			<a href="https://themeisle.com/" target="_blank" class="wp-badge epsilon-welcome-logo"></a></div>
+        <div class="header">
+            <div class="info"><h1>Welcome to <?php echo esc_html( $this->theme['name'] ); ?>! - Version <span
+                            class="version-container"><?php echo esc_html( $this->theme['version'] ); ?></span></h1>
+                <div class="ti-about-header-text about-text"><?php echo esc_html( $this->theme['description'] ); ?></div>
+            </div>
+            <a href="https://themeisle.com/" target="_blank" class="wp-badge epsilon-welcome-logo"></a></div>
 		<?php
 	}
 
@@ -89,6 +89,10 @@ class TI_About_Render {
 			if ( $tab_data['type'] === 'recommended_actions' && $this->about_page->get_recommended_actions_left() === 0 ) {
 				continue;
 			}
+			if ( $slug === 'welcome_notice' ) {
+				continue;
+			}
+
 			echo '<li data-tab-id="' . esc_attr( $slug ) . '">';
 			echo '<a class="nav-tab';
 			if ( $tab_data['type'] === 'recommended_actions' ) {
@@ -114,6 +118,10 @@ class TI_About_Render {
 			if ( $slug === 'recommended_actions' && $this->about_page->get_recommended_actions_left() === 0 ) {
 				continue;
 			}
+			if ( $slug === 'welcome_notice' ) {
+				continue;
+			}
+
 			echo '<div id="' . esc_attr( $slug ) . '" class="' . esc_attr( $tab_data['type'] ) . '">';
 
 			switch ( $tab_data['type'] ) {
@@ -164,10 +172,10 @@ class TI_About_Render {
 			echo '<h3>' . $plugin['name'] . '</h3>';
 			if ( ! empty( $plugin['description'] ) ) {
 				echo '<p>' . $plugin['description'] . '</p>';
-            } else {
-                $plugin_description = $this->call_plugin_api( $slug );
+			} else {
+				$plugin_description = $this->call_plugin_api( $slug );
 				echo '<p>' . $plugin_description->short_description . '</p>';
-            }
+			}
 			echo Ti_About_Plugin_Helper::instance()->get_button_html( $slug, array( 'redirect' => add_query_arg( 'page', $this->theme['slug'] . '-welcome', admin_url( 'themes.php#recommended_actions' ) ) ) );
 			echo '</div>';
 		}

--- a/js/ti_about_notice_scripts.js
+++ b/js/ti_about_notice_scripts.js
@@ -1,0 +1,21 @@
+/**
+ * Main scripts file for the welcome notice
+ */
+
+/* global tiAboutNotice */
+
+(function ($) {
+    $(document).ready(function () {
+        $(document).on('click', '.notice.ti-about-notice .notice-dismiss', function () {
+            jQuery.ajax({
+                async: true,
+                type: 'POST',
+                data: {
+                    action: 'dismiss_welcome_notice',
+                    nonce: tiAboutNotice.dismissNonce
+                },
+                url: tiAboutNotice.ajaxurl
+            });
+        });
+    });
+})(jQuery);


### PR DESCRIPTION
- Welcome notice can be default or with custom content by defining a render function in the theme, or disabled by not declaring _welcome_notice_ key in the config array.
- A class from WordPress core can be added on the notice element in order to display the left colored border, for example _updated_
- Dismissed notice case for Zelle old users.
- _dismiss_option_ should be unique for each theme, otherwise if a user dismisses it in Hestia and change the theme to Neve, the notice will be already dismissed, because the About Page is the same in both themes.
