### PR TITLE
fix: remove external link from header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "codeinwp/ti-about-page",
   "description": "The theme about page for themeisle themes.",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "library",
   "license": "GPL-3.0-or-later",
   "minimum-stability": "dev",

--- a/includes/class-ti-about-render.php
+++ b/includes/class-ti-about-render.php
@@ -84,9 +84,10 @@ class TI_About_Render {
 				$white_label_options = get_option( 'ti_white_label_inputs' );
 				$white_label_options = json_decode( $white_label_options, true );
 				if ( empty( $white_label_options['theme_name'] ) ) { ?>
-					<a href="https://themeisle.com/" class="ti-logo"><img
+					<span class="ti-logo"><img
 							src="<?php echo esc_url( TI_ABOUT_PAGE_URL . 'assets/img/logo.png' ) ?>"
-							alt="logo"/></a>
+							alt="logo"/>
+					</span>
 					<?php
 				} ?>
 			</div>

--- a/load.php
+++ b/load.php
@@ -25,5 +25,5 @@ if ( ! defined( 'TI_ABOUT_PAGE_URL' ) ) {
 	define( 'TI_ABOUT_PAGE_URL', get_template_directory_uri() . '/vendor/codeinwp/ti-about-page/' );
 }
 if ( ! defined( 'TI_ABOUT_PAGE_VERSION' ) ) {
-	define( 'TI_ABOUT_PAGE_VERSION', '1.0.7' );
+	define( 'TI_ABOUT_PAGE_VERSION', '1.0.8' );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti-about-page",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "dependencies": {
     "sticky-js": "^1.2.0"
   },


### PR DESCRIPTION
Closes Codeinwp/neve#811