### PR TITLE
refactor: make Ti_Notice_Manager independent

### DIFF
--- a/class-ti-about-page.php
+++ b/class-ti-about-page.php
@@ -75,11 +75,6 @@ class Ti_About_Page {
 				'update_recommended_plugins_visibility',
 			)
 		);
-
-		if ( ! class_exists( 'Ti_Notice_Manager' ) && isset( $this->config['welcome_notice'] ) ) {
-			require_once 'includes' . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR . 'class-ti-notice-manager.php';
-			add_action( 'init', array( Ti_Notice_Manager::instance(), 'init' ) );
-		}
 	}
 
 	/**

--- a/includes/admin/class-ti-notice-manager.php
+++ b/includes/admin/class-ti-notice-manager.php
@@ -35,12 +35,11 @@ class Ti_Notice_Manager {
 	/**
 	 * Init the OrbitFox instance.
 	 *
-	 * @return Orbit_Fox_Neve_Dropin|null
+	 * @return Ti_Notice_Manager|null
 	 */
 	public static function instance() {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new self();
-			self::$instance->init();
 		}
 
 		return self::$instance;
@@ -50,7 +49,6 @@ class Ti_Notice_Manager {
 	 * Drop-in actions
 	 */
 	public function init() {
-		$this->handle_data();
 		add_action( 'admin_notices', array( $this, 'admin_notice' ), defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : 99999 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_notice_scripts' ) );
 		add_action( 'wp_ajax_ti_about_dismiss_welcome_notice', array( $this, 'remove_notice' ) );
@@ -84,10 +82,12 @@ class Ti_Notice_Manager {
 	}
 
 	/**
-	 * Handle notice data.
+	 * Set the notice data.
+	 * 
+	 * @param array<string, mixed> $data The data
+	 * @return Ti_Notice_Manager
 	 */
-	private function handle_data() {
-
+	public function set_notice_data( $data ) {
 		$default = array(
 			'type'            => 'default',
 			'render_callback' => array( $this, 'render_notice' ),
@@ -95,15 +95,13 @@ class Ti_Notice_Manager {
 			'notice_class'    => '',
 		);
 
-		$about_instance = Ti_About_Page::$instance;
-		$config         = $about_instance->config;
-		$data           = $config['welcome_notice'];
-
 		$notice_data = wp_parse_args( $data, $default );
 		if ( array_key_exists( 'dismiss_option', $notice_data ) ) {
 			self::$dismiss_key = $notice_data['dismiss_option'];
 		}
 		$this->notice_data = wp_parse_args( $data, $default );
+
+		return $this;
 	}
 
 	/**

--- a/load.php
+++ b/load.php
@@ -17,6 +17,10 @@ if ( ! class_exists( 'Ti_About_Plugin_Helper' ) ) {
 	require_once 'includes' . DIRECTORY_SEPARATOR . 'class-ti-about-plugin-helper.php';
 }
 
+if ( ! class_exists( 'Ti_Notice_Manager' ) ) {
+	require_once 'includes' . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR . 'class-ti-notice-manager.php';
+}
+
 if ( ! defined( 'TI_ABOUT_PAGE_DIR' ) ) {
 	define( 'TI_ABOUT_PAGE_DIR', get_template_directory() . '/vendor/codeinwp/ti-about-page/' );
 }


### PR DESCRIPTION
### Description

Make the Ti_Notice_Manager independent so that we can initialize the welcome notice for Hestia since TI_About_Us usage was changed in https://github.com/Codeinwp/hestia-pro/pull/2864/files to scope only in the Hestia options page.